### PR TITLE
最新verのk8s manifestでも動作するようk8s manifestを修正

### DIFF
--- a/deployment/kubernetes/cdc-service/ftgo-cdc-service.yml
+++ b/deployment/kubernetes/cdc-service/ftgo-cdc-service.yml
@@ -9,13 +9,16 @@ spec:
   selector:
     svc: ftgo-cdc-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-cdc-service
   labels:
     application: ftgo
 spec:
+  selector:
+    matchLabels:
+      svc: ftgo-cdc-service
   replicas: 1
   strategy:
     rollingUpdate:

--- a/deployment/kubernetes/scripts/kubernetes-deploy-all.sh
+++ b/deployment/kubernetes/scripts/kubernetes-deploy-all.sh
@@ -1,9 +1,10 @@
 #! /bin/bash -e
+set -vx
 
 kubectl apply -f <(cat deployment/kubernetes/stateful-services/*.yml)
 
 ./deployment/kubernetes/scripts/kubernetes-wait-for-ready-pods.sh ftgo-mysql-0 ftgo-kafka-0 ftgo-dynamodb-local-0 ftgo-zookeeper-0
 
-kubectl apply -f <(cat deployment/kubernetes/cdc-services/*.yml)
+kubectl apply -f <(cat deployment/kubernetes/cdc-service/*.yml)
 
 kubectl apply -f <(cat */src/deployment/kubernetes/*.yml)

--- a/deployment/kubernetes/stateful-services/ftgo-dynamodb-local.yml
+++ b/deployment/kubernetes/stateful-services/ftgo-dynamodb-local.yml
@@ -9,13 +9,16 @@ spec:
   selector:
     svc: ftgo-dynamodb-local
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ftgo-dynamodb-local
   labels:
     application: ftgo
 spec:
+  selector:
+    matchLabels:
+      svc: ftgo-dynamodb-local
   serviceName: "ftgo-dynamodb"
   replicas: 1
   template:

--- a/deployment/kubernetes/stateful-services/ftgo-kafka-deployment.yml
+++ b/deployment/kubernetes/stateful-services/ftgo-kafka-deployment.yml
@@ -11,11 +11,14 @@ spec:
   selector:
     role: ftgo-kafka
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ftgo-kafka
 spec:
+  selector:
+    matchLabels:
+      role: ftgo-kafka
   serviceName: "kafka"
   replicas: 1
   template:

--- a/deployment/kubernetes/stateful-services/ftgo-mysql-deployment.yml
+++ b/deployment/kubernetes/stateful-services/ftgo-mysql-deployment.yml
@@ -12,11 +12,14 @@ spec:
   selector:
     role: ftgo-mysql
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ftgo-mysql
 spec:
+  selector:
+    matchLabels:
+      role: ftgo-mysql
   serviceName: "mysql"
   replicas: 1
   template:

--- a/deployment/kubernetes/stateful-services/ftgo-zookeeper-deployment.yml
+++ b/deployment/kubernetes/stateful-services/ftgo-zookeeper-deployment.yml
@@ -12,11 +12,14 @@ spec:
   selector:
     role: ftgo-zookeeper
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ftgo-zookeeper
 spec:
+  selector:
+    matchLabels:
+      role: ftgo-zookeeper
   serviceName: "zookeeper"
   replicas: 1
   template:

--- a/ftgo-accounting-service/src/deployment/kubernetes/ftgo-accounting-service.yml
+++ b/ftgo-accounting-service/src/deployment/kubernetes/ftgo-accounting-service.yml
@@ -9,13 +9,16 @@ spec:
   selector:
     svc: ftgo-accounting-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-accounting-service
   labels:
     application: ftgo
 spec:
+  selector:
+    matchLabels:
+        svc: ftgo-accounting-service
   replicas: 1
   strategy:
     rollingUpdate:

--- a/ftgo-api-gateway/src/deployment/kubernetes/ftgo-api-gateway.yml
+++ b/ftgo-api-gateway/src/deployment/kubernetes/ftgo-api-gateway.yml
@@ -16,13 +16,16 @@ spec:
 #  loadBalancerSourceRanges:
 #    - 88.128.82.195/32
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-api-gateway
   labels:
     application: ftgo
 spec:
+  selector:
+    matchLabels:
+      svc: ftgo-api-gateway
   replicas: 1
   strategy:
     rollingUpdate:

--- a/ftgo-consumer-service/src/deployment/kubernetes/ftgo-consumer-service.yml
+++ b/ftgo-consumer-service/src/deployment/kubernetes/ftgo-consumer-service.yml
@@ -9,13 +9,16 @@ spec:
   selector:
     svc: ftgo-consumer-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-consumer-service
   labels:
     application: ftgo
 spec:
+  selector:
+    matchLabels:
+      svc: ftgo-consumer-service
   replicas: 1
   strategy:
     rollingUpdate:

--- a/ftgo-kitchen-service/src/deployment/kubernetes/ftgo-kitchen-service.yml
+++ b/ftgo-kitchen-service/src/deployment/kubernetes/ftgo-kitchen-service.yml
@@ -9,13 +9,16 @@ spec:
   selector:
     svc: ftgo-kitchen-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-kitchen-service
   labels:
     application: ftgo
 spec:
+  selector:
+    matchLabels:
+      svc: ftgo-kitchen-service
   replicas: 1
   strategy:
     rollingUpdate:

--- a/ftgo-order-history-service/src/deployment/kubernetes/ftgo-order-history-service.yml
+++ b/ftgo-order-history-service/src/deployment/kubernetes/ftgo-order-history-service.yml
@@ -9,13 +9,16 @@ spec:
   selector:
     svc: ftgo-order-history-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-order-history-service
   labels:
     application: ftgo
 spec:
+  selector:
+    matchLabels:
+        svc: ftgo-order-history-service
   replicas: 1
   strategy:
     rollingUpdate:

--- a/ftgo-order-service/src/deployment/kubernetes/ftgo-order-service.yml
+++ b/ftgo-order-service/src/deployment/kubernetes/ftgo-order-service.yml
@@ -17,13 +17,16 @@ spec:
   selector:
     svc: ftgo-order-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-order-service
   labels:
     application: ftgo
 spec:
+  selector:
+    matchLabels:
+      svc: ftgo-order-service
   replicas: 1
   strategy:
     rollingUpdate:

--- a/ftgo-restaurant-service/src/deployment/kubernetes/ftgo-restaurant-service.yml
+++ b/ftgo-restaurant-service/src/deployment/kubernetes/ftgo-restaurant-service.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     svc: ftgo-restaurant-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-restaurant-service
@@ -17,6 +17,9 @@ metadata:
     application: ftgo
     svc: ftgo-restaurant-service
 spec:
+  selector:
+    matchLabels:
+      svc: ftgo-restaurant-service
   replicas: 1
   strategy:
     rollingUpdate:


### PR DESCRIPTION
- `Deployment` と `Statefulset` のAPI Verを最新化+ValidatorをパスするようSelector追加
- Shell Script内のパスの指定ミスを修正